### PR TITLE
fix: correct Angular lifecycle hook naming in login component

### DIFF
--- a/src/app/app-modules/login/login.component.ts
+++ b/src/app/app-modules/login/login.component.ts
@@ -20,7 +20,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { Component, OnInit, ViewChild, ElementRef } from '@angular/core';
+import {Component,OnInit,AfterViewInit,ViewChild,ElementRef} from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { Router } from '@angular/router';
 import * as CryptoJS from 'crypto-js';
@@ -41,7 +41,7 @@ import { AmritTrackingService } from 'Common-UI/src/tracking';
   templateUrl: './login.component.html',
   styleUrls: ['./login.component.css'],
 })
-export class LoginComponent implements OnInit {
+export class LoginComponent implements OnInit, AfterViewInit {
   @ViewChild('captchaCmp') captchaCmp: CaptchaComponent | undefined;
   dynamictype = 'password';
   encryptedVar: any;
@@ -88,7 +88,7 @@ export class LoginComponent implements OnInit {
       sessionStorage.clear();
     }
   }
-  public AfterViewInit(): void {
+  ngAfterViewInit(): void {
     this.elementRef.nativeElement.focus();
   }
 


### PR DESCRIPTION

## Description
Fixed Angular lifecycle hook naming issue in login component.

### Changes Made
- Replaced incorrect `AfterViewInit` method with proper Angular lifecycle hook `ngAfterViewInit`
- Added `AfterViewInit` interface implementation

### Why
Angular lifecycle hooks must follow Angular naming conventions to execute correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus handling on the login form to ensure the input field is properly focused when the page loads.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PSMRI/MMU-UI/pull/341)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->