### PR TITLE
fix(auth): remove AuthGuard subscription leak on every route activati…

### DIFF
--- a/src/app/app-modules/core/services/auth-guard.service.spec.ts
+++ b/src/app/app-modules/core/services/auth-guard.service.spec.ts
@@ -1,0 +1,85 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technology
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+import { ActivatedRoute, Router } from '@angular/router';
+import { of } from 'rxjs';
+import { AuthGuard } from './auth-guard.service';
+import { AuthService } from './auth.service';
+
+describe('AuthGuard', () => {
+  let auth: jasmine.SpyObj<AuthService>;
+  let router: jasmine.SpyObj<Router>;
+  let route: ActivatedRoute;
+  let guard: AuthGuard;
+
+  beforeEach(() => {
+    auth = jasmine.createSpyObj<AuthService>('AuthService', ['validateSessionKey']);
+    router = jasmine.createSpyObj<Router>('Router', ['navigate']);
+    route = {} as ActivatedRoute;
+    guard = new AuthGuard(auth, router, route);
+  });
+
+  it('returns the validateSessionKey observable so the router can wait for it', () => {
+    auth.validateSessionKey.and.returnValue(of({ statusCode: 200, data: { username: 'u' } }));
+
+    guard.canActivate({}, {}).subscribe();
+
+    expect(auth.validateSessionKey).toHaveBeenCalledTimes(1);
+  });
+
+  it('navigates to /login when the session response is unauthorised', () => {
+    auth.validateSessionKey.and.returnValue(of({ statusCode: 401, data: null }));
+
+    guard.canActivate({}, {}).subscribe();
+
+    expect(router.navigate).toHaveBeenCalledOnceWith(['/login']);
+  });
+
+  it('does not navigate when the session response is valid', () => {
+    auth.validateSessionKey.and.returnValue(of({ statusCode: 200, data: { username: 'u' } }));
+
+    guard.canActivate({}, {}).subscribe();
+
+    expect(router.navigate).not.toHaveBeenCalled();
+  });
+
+  it('no longer holds a reference to HttpServiceService — guarantees the language subscription leak cannot recur', () => {
+    auth.validateSessionKey.and.returnValue(of({ statusCode: 200, data: { username: 'u' } }));
+
+    // The pre-fix implementation injected HttpServiceService and assigned the
+    // emitted value to `current_language_set` on every navigation without
+    // tearing the subscription down. Both fields must be gone so the leak
+    // cannot be re-introduced silently.
+    expect((guard as unknown as { http_service: unknown }).http_service).toBeUndefined();
+    expect((guard as unknown as { current_language_set: unknown }).current_language_set).toBeUndefined();
+  });
+
+  it('processes repeated navigations without accumulating per-call subscriptions on the guard instance', () => {
+    auth.validateSessionKey.and.returnValue(of({ statusCode: 200, data: { username: 'u' } }));
+
+    for (let i = 0; i < 20; i += 1) {
+      guard.canActivate({}, {}).subscribe();
+    }
+
+    expect(auth.validateSessionKey).toHaveBeenCalledTimes(20);
+    expect((guard as unknown as { http_service: unknown }).http_service).toBeUndefined();
+  });
+});

--- a/src/app/app-modules/core/services/auth-guard.service.ts
+++ b/src/app/app-modules/core/services/auth-guard.service.ts
@@ -1,22 +1,16 @@
 import { Injectable } from '@angular/core';
 import { CanActivate, Router, ActivatedRoute } from '@angular/router';
 import { tap } from 'rxjs';
-import { HttpServiceService } from '../../core/services/http-service.service';
 import { AuthService } from './auth.service';
 @Injectable()
 export class AuthGuard implements CanActivate {
-  current_language_set: any;
   constructor(
     private auth: AuthService,
     private router: Router,
-    private route: ActivatedRoute,
-    private http_service: HttpServiceService
+    private route: ActivatedRoute
   ) {}
 
   canActivate(route: any, state: any) {
-    this.http_service.currentLangugae$.subscribe(
-      response => (this.current_language_set = response)
-    );
     return this.auth.validateSessionKey().pipe(
       tap((res: any) => {
         if (!(res && res.statusCode === 200 && res.data)) {


### PR DESCRIPTION


AuthGuard.canActivate() subscribed to HttpServiceService.currentLangugae$ on every invocation and stored the emitted value in current_language_set. currentLangugae$ is exposed as `BehaviorSubject(...).asObservable()` and never completes, so each protected route activation appended a fresh subscriber that was never released. Since AuthGuard is a singleton @Injectable used by canActivate on seven protected routes (service, servicePoint, registrar, nurse-doctor, lab, pharmacist, datasync), repeated navigation accumulated subscribers indefinitely.

current_language_set was assigned inside the subscribe callback but never read anywhere in the guard, in templates, or by reflective access from sibling code. The subscription served no purpose; the correct fix is to delete it rather than convert it to take(1) or takeUntilDestroyed — there is no consumer to feed.

Changes:

* auth-guard.service.ts: remove the dead `current_language_set` field, the dead currentLangugae$ subscription, the HttpServiceService dependency injection, and the now-unused import. Guard logic reduces to the session-key validation pipeline it always relied on.

* auth-guard.service.spec.ts: new spec that locks in the no-leak contract — verifies the guard no longer holds a reference to HttpServiceService or `current_language_set`, that 20 sequential canActivate calls do not regrow the field, and that the existing navigation semantics (route to /login on invalid session, no-op on valid session) are preserved.

## 📋 Description

JIRA ID: 

Please provide a summary of the change and the motivation behind it. Include relevant context and details.

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.
