### PR TITLE
correcting Angular AfterViewInit lifecycle hook in LoginComponent

### DIFF
--- a/src/app/app-modules/login/login.component.ts
+++ b/src/app/app-modules/login/login.component.ts
@@ -20,7 +20,13 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { Component, OnInit, ViewChild, ElementRef } from '@angular/core';
+import {
+  Component,
+  OnInit,
+  ViewChild,
+  ElementRef,
+  AfterViewInit,
+} from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { Router } from '@angular/router';
 import * as CryptoJS from 'crypto-js';
@@ -41,7 +47,7 @@ import { AmritTrackingService } from 'Common-UI/src/tracking';
   templateUrl: './login.component.html',
   styleUrls: ['./login.component.css'],
 })
-export class LoginComponent implements OnInit {
+export class LoginComponent implements OnInit, AfterViewInit {
   @ViewChild('captchaCmp') captchaCmp: CaptchaComponent | undefined;
   dynamictype = 'password';
   encryptedVar: any;
@@ -88,7 +94,7 @@ export class LoginComponent implements OnInit {
       sessionStorage.clear();
     }
   }
-  public AfterViewInit(): void {
+  ngAfterViewInit(): void {
     this.elementRef.nativeElement.focus();
   }
 


### PR DESCRIPTION
## 📋 Description

JIRA ID: 

Fixed an issue in LoginComponent where the AfterViewInit lifecycle hook was not executing because it was defined without the mandatory ng prefix.
---

## ✅ Type of Change

- [x] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [x] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.
