### PR TITLE
fix(rxjs): replace internal rxjs imports with public API paths

### DIFF
--- a/src/app/app-modules/core/components/camera-dialog/camera-dialog.component.ts
+++ b/src/app/app-modules/core/components/camera-dialog/camera-dialog.component.ts
@@ -34,11 +34,10 @@ import { MatDialogRef } from '@angular/material/dialog';
 import { HttpServiceService } from '../../services/http-service.service';
 import { ConfirmationService } from '../../services';
 import { SetLanguageComponent } from '../set-language.component';
-import { Subject } from 'rxjs/internal/Subject';
 import { ChartData, ChartType } from 'chart.js';
 import html2canvas from 'html2canvas';
 import { WebcamImage, WebcamInitError } from 'ngx-webcam';
-import { Observable } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
 import { saveAs } from 'file-saver';
 import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
 

--- a/src/app/app-modules/core/services/http-interceptor.service.ts
+++ b/src/app/app-modules/core/services/http-interceptor.service.ts
@@ -10,9 +10,8 @@ import {
   HttpHeaders,
 } from '@angular/common/http';
 import { catchError, tap, finalize } from 'rxjs/operators';
-import { Observable, of, Subject, EMPTY } from 'rxjs';
+import { Observable, of, Subject, EMPTY, throwError } from 'rxjs';
 import { Router } from '@angular/router';
-import { throwError } from 'rxjs/internal/observable/throwError';
 import { SpinnerService } from './spinner.service';
 import { ConfirmationService } from './confirmation.service';
 import { environment } from 'src/environments/environment';

--- a/src/app/app-modules/registrar/registration/registration.component.ts
+++ b/src/app/app-modules/registrar/registration/registration.component.ts
@@ -39,8 +39,7 @@ import { RegistrationUtils } from '../shared/utility/registration-utility';
 import { CanComponentDeactivate } from '../../core/services/can-deactivate-guard.service';
 import { HttpServiceService } from '../../core/services/http-service.service';
 import { SetLanguageComponent } from '../../core/components/set-language.component';
-import { Observable } from 'rxjs/internal/Observable';
-import { of } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { RegistrarService } from '../shared/services/registrar.service';
 import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
 

--- a/src/app/app-modules/registrar/shared/services/registrar.service.ts
+++ b/src/app/app-modules/registrar/shared/services/registrar.service.ts
@@ -22,7 +22,7 @@
 
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { BehaviorSubject } from 'rxjs/internal/BehaviorSubject';
+import { BehaviorSubject } from 'rxjs';
 import { environment } from 'src/environments/environment';
 
 @Injectable()


### PR DESCRIPTION
## 📋 Description

Replaces 4 imports from `rxjs/internal/*` with the public `rxjs` API.

Internal imports are undocumented, not part of the public API contract, and can break on minor/patch RxJS version upgrades.

## ✅ Type of Change

- [x] 🐞 **Bug fix** (non-breaking change which resolves an issue)

## ℹ️ Additional Information

**Files changed:**
- `camera-dialog.component.ts` — `Subject` from `rxjs/internal/Subject` → `rxjs`
- `http-interceptor.service.ts` — `throwError` from `rxjs/internal/observable/throwError` → `rxjs`
- `registration.component.ts` — `Observable` from `rxjs/internal/Observable` → `rxjs`
- `registrar.service.ts` — `BehaviorSubject` from `rxjs/internal/BehaviorSubject` → `rxjs`

Zero behavior change. All symbols are re-exported from the public `rxjs` entry point.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency imports across multiple components and services for improved code consistency and maintainability. No functional changes or user-facing impact.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PSMRI/MMU-UI/pull/357)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->