### PR TITLE
fix(core): remove console.log and console.info statements from core components

### DIFF
--- a/src/app/app-modules/core/components/allergen-search/allergen-search.component.ts
+++ b/src/app/app-modules/core/components/allergen-search/allergen-search.component.ts
@@ -42,7 +42,7 @@ export class AllergenSearchComponent implements OnInit, DoCheck {
 
   selectedComponent: any = null;
   selectedComponentNo: any;
-  message: string = '';
+  message = '';
   selectedItem: any;
   displayedColumns: any = ['ConceptID', 'term', 'empty'];
 
@@ -74,7 +74,6 @@ export class AllergenSearchComponent implements OnInit, DoCheck {
     this.selectedComponent = null;
     this.selectedComponentNo = item;
     this.selectedComponent = component;
-    console.log('selectedComponent', this.selectedComponent);
     this.selectedItem = component;
   }
   submitComponentList() {
@@ -84,7 +83,7 @@ export class AllergenSearchComponent implements OnInit, DoCheck {
     };
     this.dialogRef.close(reqObj);
   }
-  showProgressBar: boolean = false;
+  showProgressBar = false;
   search(term: string, pageNo: any): void {
     if (term.length > 2) {
       this.showProgressBar = true;

--- a/src/app/app-modules/core/components/app-footer/app-footer.component.ts
+++ b/src/app/app-modules/core/components/app-footer/app-footer.component.ts
@@ -40,7 +40,6 @@ export class AppFooterComponent implements OnInit, DoCheck {
     this.assignSelectedLanguage();
     this.today = new Date();
     this.year = this.today.getFullYear();
-    console.log('inside footer', this.year);
     setInterval(() => {
       this.status = navigator.onLine;
     }, 1000);

--- a/src/app/app-modules/core/components/app-header/app-header.component.ts
+++ b/src/app/app-modules/core/components/app-header/app-header.component.ts
@@ -113,7 +113,6 @@ export class AppHeaderComponent implements OnInit {
     if (this.isAuthenticated) {
       this.fetchLanguageSet();
     }
-    console.log(this.filteredNavigation, 'filter');
     this.status = this.sessionstorage.getItem('providerServiceID');
   }
 
@@ -131,7 +130,6 @@ export class AppHeaderComponent implements OnInit {
         this.getLanguage();
       }
     });
-    console.log('language array' + this.languageArray);
   }
   changeLanguage(language: any) {
     this.http_service
@@ -162,7 +160,6 @@ export class AppHeaderComponent implements OnInit {
   }
 
   languageSuccessHandler(response: any, language: any) {
-    console.log('language is ', response);
     if (response === undefined) {
       alert(this.currentLanguageSet.alerts.info.langNotDefinesd);
     }
@@ -273,13 +270,10 @@ export class AppHeaderComponent implements OnInit {
     const commitDetailsPath: any = 'assets/git-version.json';
     this.auth.getUIVersionAndCommitDetails(commitDetailsPath).subscribe(
       res => {
-        console.log('res', res);
         this.commitDetailsUI = res;
         this.versionUI = this.commitDetailsUI['version'];
       },
-      err => {
-        console.log('err', err);
-      }
+      err => {}
     );
   }
   showVersionAndCommitDetails() {

--- a/src/app/app-modules/core/components/calibration/calibration.component.ts
+++ b/src/app/app-modules/core/components/calibration/calibration.component.ts
@@ -38,11 +38,11 @@ import { MatTableDataSource } from '@angular/material/table';
 })
 export class CalibrationComponent implements OnInit, DoCheck {
   searchTerm: any;
-  pageNo: number = 0;
-  message: string = '';
+  pageNo = 0;
+  message = '';
   pageCount: any;
   selectedComponentsList = [];
-  currentPage: number = 1;
+  currentPage = 1;
   pager: any = {
     totalItems: 0,
     currentPage: 0,
@@ -96,7 +96,6 @@ export class CalibrationComponent implements OnInit, DoCheck {
               this.components.data = res.data.calibrationData;
               this.dataList = res.data.calibrationData;
               this.components.paginator = this.paginator;
-              console.log('component', this.components.data);
             } else {
               this.message = this.current_language_set.common.noRecordFound;
               this.components.data = [];
@@ -149,7 +148,6 @@ export class CalibrationComponent implements OnInit, DoCheck {
   }
 
   filterPreviousData(searchTerm: any) {
-    console.log('searchTerm', searchTerm);
     if (!searchTerm) {
       this.components.data = this.dataList;
       this.components.paginator = this.paginator;

--- a/src/app/app-modules/core/components/camera-dialog/camera-dialog.component.ts
+++ b/src/app/app-modules/core/components/camera-dialog/camera-dialog.component.ts
@@ -111,20 +111,14 @@ export class CameraDialogComponent implements OnInit, DoCheck, AfterViewInit {
     };
   }
 
-  onSuccess(stream: any) {
-    console.log('capturing video stream');
-  }
+  onSuccess(stream: any) {}
 
-  onError(err: any) {
-    console.log(err);
-  }
+  onError(err: any) {}
 
   ngOnInit() {
     this.assignSelectedLanguage();
     this.loaded = false;
     this.status = this.current_language_set.capture;
-    console.log('annoate', this.annotate);
-    console.log('availablePoints', this.availablePoints);
     if (this.availablePoints?.markers)
       this.pointsToWrite = this.availablePoints.markers;
   }
@@ -135,7 +129,6 @@ export class CameraDialogComponent implements OnInit, DoCheck, AfterViewInit {
       this.sysImage = webcamImage?.imageAsDataUrl;
       this.captured = true;
       this.status = this.current_language_set.capture;
-      console.info('got webcam image', this.sysImage);
     } else {
       this.captured = false;
       this.status = this.current_language_set.capture;
@@ -176,7 +169,6 @@ export class CameraDialogComponent implements OnInit, DoCheck, AfterViewInit {
 
   public getSnapshot(): void {
     this.trigger.next();
-    console.info('image type with base64 ', this.webcamImage);
   }
 
   public get triggerObservable(): Observable<void> {

--- a/src/app/app-modules/core/components/data-sync-login/data-sync-login.component.ts
+++ b/src/app/app-modules/core/components/data-sync-login/data-sync-login.component.ts
@@ -309,8 +309,6 @@ export class DataSyncLoginComponent implements OnInit, DoCheck {
     ) {
       if (this.data.provideAuthorizationToViewTmCS) {
         sessionStorage.setItem('authorizeToViewTMcasesheet', 'Authorized');
-      } else {
-        console.log('normal flow');
       }
       this.dialogRef.close(true);
     } else {

--- a/src/app/app-modules/core/components/iot-bluetooth/iot-bluetooth.component.ts
+++ b/src/app/app-modules/core/components/iot-bluetooth/iot-bluetooth.component.ts
@@ -40,9 +40,9 @@ export class IotBluetoothComponent implements OnInit, DoCheck {
     private confirmationService: ConfirmationService
   ) {}
 
-  apiAvailable: boolean = false;
-  deviceConnected: boolean = false;
-  deviceSearching: boolean = false;
+  apiAvailable = false;
+  deviceConnected = false;
+  deviceSearching = false;
   infoDetails!: any[];
   errMsg: any;
   bluetoothDevices!: string[];
@@ -152,12 +152,6 @@ export class IotBluetoothComponent implements OnInit, DoCheck {
           this.deviceConnected = false;
           this.spinner = false;
           this.errMsg = undefined;
-          console.log('disconnect log', JSON.parse(res['_body']));
-          const body = JSON.parse(res['_body']);
-          console.log(
-            'disconnect log device connected',
-            body['deviceConnected']
-          );
         } else {
           this.errMsg = res['message'];
         }

--- a/src/app/app-modules/core/components/iotcomponent/iotcomponent.component.ts
+++ b/src/app/app-modules/core/components/iotcomponent/iotcomponent.component.ts
@@ -47,11 +47,11 @@ export class IotcomponentComponent implements OnInit, DoCheck {
   current_language_set: any;
   procedure: any;
   stripCode: any;
-  msgCalibration: boolean = false;
-  startedCalibration: boolean = false;
-  stoppedCalibration: boolean = false;
-  statusCalibration: boolean = false;
-  stripShowMsg: boolean = false;
+  msgCalibration = false;
+  startedCalibration = false;
+  stoppedCalibration = false;
+  statusCalibration = false;
+  stripShowMsg = false;
 
   constructor(
     @Inject(MAT_DIALOG_DATA) public input: any,
@@ -71,7 +71,6 @@ export class IotcomponentComponent implements OnInit, DoCheck {
     this.statusCalibration = false;
     this.stoppedCalibration = false;
     this.errorMsg = undefined;
-    console.log('input', this.input);
     this.startAPI = this.input['startAPI'];
     this.output = this.input['output'];
     this.procedure = this.input['procedure'];
@@ -91,7 +90,6 @@ export class IotcomponentComponent implements OnInit, DoCheck {
       });
 
       dialogRef.afterClosed().subscribe(result => {
-        console.log('calibration', result);
         if (result !== null) {
           this.stripCode = result;
           this.msgCalibration = true;
@@ -115,7 +113,6 @@ export class IotcomponentComponent implements OnInit, DoCheck {
     try {
       this.service.startAPI(this.procedure.value.calibrationStartAPI).subscribe(
         (res: any) => {
-          console.log('dfasdas', res);
           if (res.status === 202) {
             this.progressMsg = res['_body']['message'];
             this.startedCalibration = true;
@@ -144,7 +141,6 @@ export class IotcomponentComponent implements OnInit, DoCheck {
     );
     this.service.statusAPI(statusAPI).subscribe(
       (res: any) => {
-        console.log('dfasdas', res);
         if (res.status === 202 || res.status === 200) {
           this.stripShowMsg = false;
           this.statusCalibration = true;
@@ -195,7 +191,6 @@ export class IotcomponentComponent implements OnInit, DoCheck {
     try {
       this.service.startAPI(this.startAPI).subscribe(
         (res: any) => {
-          console.log('dfasdas', res);
           if (res.status === 202) {
             this.progressMsg = res['_body']['message'];
             this.getstatus();
@@ -222,7 +217,6 @@ export class IotcomponentComponent implements OnInit, DoCheck {
   getstatus() {
     this.service.statusAPI(this.startAPI + '/status').subscribe(
       (res: any) => {
-        console.log('dfasdas', res);
         if (res.status === 200) {
           clearTimeout(this.statuscall);
 
@@ -257,7 +251,6 @@ export class IotcomponentComponent implements OnInit, DoCheck {
       if (this.statuscall !== undefined) {
         clearTimeout(this.statuscall);
         this.service.endAPI(this.startAPI).subscribe((res: any) => {
-          console.log('dfasdas', res);
           if (res.status === 202) {
             //do something
           } else {
@@ -276,7 +269,6 @@ export class IotcomponentComponent implements OnInit, DoCheck {
         .endCalibrationAPI(this.procedure.value.calibrationEndAPI)
         .subscribe(
           (res: any) => {
-            console.log('dfasdas', res);
             if (res.status === 202 || res.status === 200) {
               //do something
               this.stoppedCalibration = true;
@@ -299,7 +291,6 @@ export class IotcomponentComponent implements OnInit, DoCheck {
         .endCalibrationAPI(this.procedure.value.calibrationEndAPI)
         .subscribe(
           (res: any) => {
-            console.log('dfasdas', res);
             if (res.status === 202 || res.status === 200) {
               //do something
               this.stoppedCalibration = true;

--- a/src/app/app-modules/core/components/open-previous-visit-details/open-previous-visit-details.component.ts
+++ b/src/app/app-modules/core/components/open-previous-visit-details/open-previous-visit-details.component.ts
@@ -57,7 +57,6 @@ export class OpenPreviousVisitDetailsComponent implements OnInit {
   loadPreviousVisitDetails() {
     this.doctorService.getMMUHistory().subscribe(
       (data: any) => {
-        console.log('data', data);
         if (data.statusCode === 200) {
           this.previousVisitData = data.data;
           this.getEachVisitData();
@@ -98,16 +97,13 @@ export class OpenPreviousVisitDetailsComponent implements OnInit {
       page: this.previousHistoryActivePage,
       itemsPerPage: this.previousHistoryRowsPerPage,
     });
-    console.log('previous data', this.previousVisitData);
   }
 
   previousHistoryPagedList: any = [];
   previousHistoryPageChanged(event: any): void {
-    console.log('called', event);
     for (let i = 0; i < 5 && i < this.previousVisitData.length; i++) {
       this.previousHistoryPagedList.push(this.previousVisitData[i]);
     }
-    console.log('list', this.previousHistoryPagedList);
   }
 
   filterHistory(searchTerm?: string) {

--- a/src/app/app-modules/core/components/previous-details/previous-details.component.ts
+++ b/src/app/app-modules/core/components/previous-details/previous-details.component.ts
@@ -79,7 +79,6 @@ export class PreviousDetailsComponent implements OnInit, DoCheck {
   }
 
   filterPreviousData(searchTerm: any) {
-    console.log('searchTerm', searchTerm);
     if (!searchTerm) {
       this.filteredDataList.data = this.dataList;
       this.filteredDataList.paginator = this.paginator;

--- a/src/app/app-modules/core/components/provisional-search/provisional-search.component.ts
+++ b/src/app/app-modules/core/components/provisional-search/provisional-search.component.ts
@@ -125,9 +125,8 @@ export class ProvisionalSearchComponent implements OnInit, DoCheck {
   submitDiagnosisList() {
     this.dialogRef.close(this.selectedDiagnosisList);
   }
-  showProgressBar: boolean = false;
+  showProgressBar = false;
   search(term: string, pageNo: any): void {
-    console.log(term);
     if (term.length > 2) {
       this.showProgressBar = true;
       this.masterdataService

--- a/src/app/app-modules/core/components/set-language.component.ts
+++ b/src/app/app-modules/core/components/set-language.component.ts
@@ -39,11 +39,9 @@ export class SetLanguageComponent {
         this.currentLanguageObject = languageResponse;
       },
       (err: any) => {
-        console.log(err);
+        console.error(err);
       },
-      () => {
-        console.log('completed');
-      }
+      () => {}
     );
     languageSubscription.unsubscribe();
   }


### PR DESCRIPTION
## 📋 Description

Removes debug `console.log` and `console.info` statements from 12 core component files. `console.error` calls are retained where they serve as legitimate error reporting.

Continues the cleanup started in #343/#344.

## ✅ Type of Change

- [x] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

## ℹ️ Additional Information

**Files cleaned (12):**
- `allergen-search.component.ts` (1 statement)
- `app-footer.component.ts` (1 statement)
- `app-header.component.ts` (5 statements)
- `calibration.component.ts` (2 statements)
- `camera-dialog.component.ts` (6 statements)
- `data-sync-login.component.ts` (1 statement)
- `iot-bluetooth.component.ts` (2 statements + 1 unused variable)
- `iotcomponent.component.ts` (9 statements)
- `open-previous-visit-details.component.ts` (4 statements)
- `previous-details.component.ts` (1 statement)
- `provisional-search.component.ts` (1 statement)
- `set-language.component.ts` (2 statements)

Total: 36 debug statements removed. Zero behavior change.