### PR TITLE
fix(data-sync): correct always-true auth condition in workarea

### DIFF
--- a/src/app/app-modules/data-sync/workarea/workarea.component.ts
+++ b/src/app/app-modules/data-sync/workarea/workarea.component.ts
@@ -66,10 +66,8 @@ export class WorkareaComponent
 
   ngOnInit() {
     this.assignSelectedLanguage();
-    if (
-      this.sessionstorage.getItem('serverKey') !== null ||
-      this.sessionstorage.getItem('serverKey') !== undefined
-    ) {
+    const serverKey = this.sessionstorage.getItem('serverKey');
+    if (serverKey) {
       this.getDataSYNCGroup();
     } else {
       this.router.navigate(['datasync/sync-login']);
@@ -348,8 +346,7 @@ export class WorkareaComponent
           this.dataSyncService
             .inventorySyncDownloadData(vanID)
             .subscribe((res: any) => {
-              if (res.statusCode === 200) {
-              } else {
+              if (res.statusCode !== 200) {
                 this.confirmationService.alert(res.errorMessage, 'error');
               }
             });


### PR DESCRIPTION
## 📋 Description

The `serverKey` null-check in `DataSync WorkareaComponent.ngOnInit()` uses `!== null || !== undefined`, which is always true (De Morgan's law). The `else` branch that redirects unauthenticated users to `datasync/sync-login` never executes.

Replaced with a truthy check on an extracted variable, which also avoids calling `getItem()` (and its decryption logic) twice.

Additionally inverted an empty `if` block for the inventory sync response to fix a pre-existing lint error (`no-empty`).

## ✅ Type of Change

- [x] 🐞 **Bug fix** (non-breaking change which resolves an issue)

## ℹ️ Additional Information

**Before (always true):**
```typescript
if (
  this.sessionstorage.getItem('serverKey') !== null ||
  this.sessionstorage.getItem('serverKey') !== undefined
)
```

**After:**
```typescript
const serverKey = this.sessionstorage.getItem('serverKey');
if (serverKey) {
```

Truth table proving the bug:
| `getItem()` returns | `!== null` | `!== undefined` | `\|\|` result |
|---|---|---|---|
| `null` | false | true | **true** |
| `undefined` | true | false | **true** |
| `"abc"` | true | true | **true** |

The else branch was dead code.