### PR TITLE
fix(core): replace innerHTML with textContent in password directive

### DIFF
--- a/src/app/app-modules/core/directives/password/myPassword.directive.ts
+++ b/src/app/app-modules/core/directives/password/myPassword.directive.ts
@@ -43,16 +43,16 @@ export class MyPasswordDirective {
   @HostListener('keyup', ['$event']) onKeyUp(ev: any) {
     const result = this.passwordValidator(ev.target.value);
     if (result === 1) {
-      ev.target.nextSibling.nextElementSibling.innerHTML = 'Strong Password';
+      ev.target.nextSibling.nextElementSibling.textContent = 'Strong Password';
       ev.target.style.border = '2px solid green';
     }
     if (result === 0) {
-      ev.target.nextSibling.nextElementSibling.innerHTML = 'Weak Password';
+      ev.target.nextSibling.nextElementSibling.textContent = 'Weak Password';
       ev.target.style.border = '2px solid yellow';
     }
 
     if (result === -1) {
-      ev.target.nextSibling.nextElementSibling.innerHTML =
+      ev.target.nextSibling.nextElementSibling.textContent =
         'password should be 8-12 characters long and must start with an alphabet and can have numbers alphabets and $%#@!&^*()-+{}[]';
       ev.target.style.border = '2px solid red';
     }


### PR DESCRIPTION
## 📋 Description

`myPassword.directive.ts` uses `innerHTML` to display plain text feedback ("Strong Password", "Weak Password", etc.). Since these are non-HTML strings, `innerHTML` is unnecessary and introduces an XSS vector. Replaced with `textContent` which is safer and functionally identical for plain text.

## ✅ Type of Change

- [x] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [x] 🚀 **Performance** (improves performance)

## ℹ️ Additional Information

- `textContent` does not invoke the HTML parser, making it marginally faster
- `textContent` is immune to XSS by design — it treats all input as text, never as markup
- No behavior change since all assigned strings are plain text with no HTML tags